### PR TITLE
Add Twitter links

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,38 +7,13 @@
     <meta name="description" content="We are in a climate emergency. We need to keep fossil fuels in the ground. Now. Start by unliking all the companies that continue to actively promoting its use."</meta>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://fonts.googleapis.com/css?family=Nunito+Sans&display=swap" rel="stylesheet">
-    <style>
-      body {
-        font-family: 'Nunito Sans', sans-serif;
-      }      
-      iframe {
-        margin: 5px 0;
-      }
-      #page {
-        max-width:900px;
-        margin: 0 auto;
-      }
-      h1 span {
-        float: left;
-        margin-right: 10px;
-      }
-      h2 {
-        text-transform: uppercase;
-        margin: 20px 0 -5px 0;
-        font-size: 14pt;
-      }
-      p.description {
-        color: #982429;
-        clear: both;
-        font-size: 14pt;
-      }
-    </style>
+    <link href="./style.css" rel="stylesheet">
   </head>
   <body>
     <div id="page">
 
     <h1><span>UnlikeFossilFuels</span> <span>💔🛢🔥🌍⏳</span></h1>
-    <p class="description">Unlike the facebook pages of companies that promote
+    <p class="description">Unlike/unfollow the Facebook/Twitter pages of companies that promote
       fossil fuels</p>
     <p>
       We are in a climate emergency. We need to keep fossil fuels in the ground.
@@ -48,21 +23,46 @@
 
     <h2>Car manufacturers</h2>
     <p>While most car manufacturers are now heavily investing in electric vehicles (they have to), they all still continue to spend advertising dollars to promote SUV and combustible engines. In other words, they are still putting oil on the fire.</p>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FAudi%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FBMW%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FFord%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FGeneralMotors%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FHyundai%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FKia%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FLandRover%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FMercedesBenz%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FOpel%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FPeugeot%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FPorsche%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FRenault%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Ftoyota%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FVolkswagen%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-    
+    <div class="tabs">
+      <input type="radio" checked name="tab" id="facebook">
+      <label for="facebook">Facebook</label>
+
+      <input type="radio" name="tab" id="twitter">
+      <label for="twitter">Twitter</label>
+
+      <div class="tab-content" id="facebook">
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FAudi%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FBMW%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FFord%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FGeneralMotors%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FHyundai%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FKia%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FLandRover%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FMercedesBenz%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FOpel%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FPeugeot%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FPorsche%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FRenault%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Ftoyota%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FVolkswagen%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>  
+      </div>
+      <div class="tab-content" id="twitter">
+        <div id="twitter-description">(These all say "Follow @X", but each button will allow you to unfollow an account if you're currently following it.)</div>
+        <a href="https://twitter.com/AudiOfficial?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @AudiOfficial</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/BMW?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @BMW</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/Ford?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Ford</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/Hyundai?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Hyundai</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/Kia?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Kia</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/LandRover?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @LandRover</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/MercedesBenz?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @MercedesBenz</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/Opel?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Opel</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/Peugeot?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Peugeot</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/Porsche?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Porsche</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/Groupe_Renault?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Renault</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/Toyota?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Toyota</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/VW?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @VW</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+      </div>
+    </div>
     <hr />
     <p>Contribute on <a href="https://github.com/allforclimate/UnlikeFossilFuels">GitHub</a></p>
   </div>

--- a/index.html
+++ b/index.html
@@ -63,20 +63,7 @@ Unlike the facebook pages of companies that promote fossil fuels and nudge your 
         <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FVolkswagen%2F&tabs&width=340&height=150&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=true&appId=110203902358957" width="340" height="150" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>  
       </div>
       <div class="tab-content" id="twitter">
-        <div id="twitter-description">(These all say "Follow @X", but each button will allow you to unfollow an account if you're currently following it.)</div>
-        <a href="https://twitter.com/AudiOfficial?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @AudiOfficial</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/BMW?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @BMW</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/Ford?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Ford</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/Hyundai?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Hyundai</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/Kia?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Kia</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/LandRover?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @LandRover</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/MercedesBenz?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @MercedesBenz</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/Opel?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Opel</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/Peugeot?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Peugeot</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/Porsche?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Porsche</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/Groupe_Renault?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Renault</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/Toyota?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @Toyota</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        <a href="https://twitter.com/VW?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @VW</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <a href="https://twitter.com/_jlevers/lists/car-manufacturers/members">This Twitter list</a> aggregates all the companies whose Facebook profiles are linked in the other tab, so that you can unfollow them all in one convenient place.
       </div>
     </div>
     <hr />

--- a/style.css
+++ b/style.css
@@ -1,0 +1,64 @@
+body {
+    font-family: 'Nunito Sans', sans-serif;
+}
+
+.tabs input {
+    display: none;
+}
+
+.tabs label {
+    display: block;
+    float: left;
+    padding: 3px 8px;
+    cursor: pointer;
+    font-size: 20px;
+    border: 1px solid gray;
+    border-radius: 5px 5px 0 0;
+    background-color: lightgray;
+}
+
+.tabs input:checked + label {
+    background-color: white;
+    border-bottom: 0;
+}
+
+.tabs .tab-content {
+    display: none;
+    padding: 5px 10px;
+    clear: left;
+}
+
+.tabs input:nth-of-type(1):checked ~ .tab-content:nth-of-type(1),
+.tabs input:nth-of-type(2):checked ~ .tab-content:nth-of-type(2) {
+    display: block;
+}
+
+.tab-content#twitter #twitter-description {
+    padding-bottom: 10px;
+}
+
+iframe {
+    margin: 5px 0;
+}
+
+#page {
+    max-width:900px;
+    margin: 0 auto;
+}
+
+h1 span {
+    float: left;
+    margin-right: 10px;
+}
+
+h2 {
+    text-transform: uppercase;
+    margin: 20px 0 -5px 0;
+    font-size: 14pt;
+}
+
+p.description {
+    color: #982429;
+    clear: both;
+    font-size: 14pt;
+}


### PR DESCRIPTION
I added Twitter links to the homepage, in a separate tab from the Facebook links, so that people can see the links for each company separately.

Twitter only provides a very simplistic "Follow @<name>" embeddable widget, and the widget renders an `<iframe>` in place of the `<a>` tag that they give you to embed in your page, so it's difficult to modify the widget to say "Unfollow" instead of "Follow".

If you'd like me to change anything else about this, let me know! Styling isn't my strong suit, so I'm very open to stylistic changes/suggestions.